### PR TITLE
fixes #15 by only pulling the kind of content the field can handle

### DIFF
--- a/lib/concerto_emergency/engine.rb
+++ b/lib/concerto_emergency/engine.rb
@@ -27,9 +27,10 @@ module ConcertoEmergency
         add_controller_hook "Screen", :frontend_display, :before do
 
           emergency_feed = Feed.find_by_name(ConcertoConfig[:emergency_feed])
+          emergency_active = emergency_feed.submissions.approved.active.includes(:content).where("kind_id != 4").present?
 
           # Check for emergency content 
-          if not emergency_feed.nil? and not emergency_feed.submissions.approved.active.includes(:content).where("kind_id != 4").empty?
+          if not emergency_feed.nil? and emergency_active
             # swap template to emergency template if emergency content is present
             emergency_template = Template.find_by_name(ConcertoConfig[:emergency_template])
             if not emergency_template.nil?

--- a/lib/concerto_emergency/engine.rb
+++ b/lib/concerto_emergency/engine.rb
@@ -46,7 +46,7 @@ module ConcertoEmergency
           emergency_feed = Feed.find_by_name(ConcertoConfig[:emergency_feed])
           
           if not emergency_feed.nil?
-            emergency_submissions = emergency_feed.submissions.approved.active
+            emergency_submissions = emergency_feed.submissions.approved.active.includes(:content).where("kind_id = ?", @field.kind_id)
             emergency_contents = Array.new()
             emergency_submissions.each { |submission| emergency_contents << Content.find(submission.content_id) }
         


### PR DESCRIPTION
Since we cannot use subscriptions to filter the content like the non-emergency frontend contents_controller does (we do not have a specific screen because by virtue of this plugin we're sending to all screens) we instead filter by the type of content that the field can handle.

What was happening was that all submitted, approved content in the emergency feed was going to all fields-- so it was showing graphics in the ticker and text areas and text and ticker content in the graphic areas. 

@gbprz should look this over and make sure it still satisfies his expectations before merging.